### PR TITLE
Fix inconsitencies in docs and examples, added ingredient name as a field in the ingredient dict

### DIFF
--- a/doc/topics/reference/orf.rst
+++ b/doc/topics/reference/orf.rst
@@ -42,6 +42,10 @@ ingredient
 A dict of items, describing an ingredient, and how much of that ingredient to
 use.
 
+ingredient
+``````````
+The name of the ingredient.
+
 amounts
 ```````
 A list of dicts which describe the amounts to use. Normally, the list will only

--- a/examples/banana-bread.yaml
+++ b/examples/banana-bread.yaml
@@ -1,91 +1,94 @@
-recipe_uuid: None
+recipe_uuid:
 recipe_name: Banana Bread
-author: Joseph Hall <perlhoser@gmail.com>
-source_url: None
-source_book: None
-oven_temp: 350F
+source_authors: Joseph Hall <perlhoser@gmail.com>
+source_url:
+source_book:
+oven_temp:
+  amount: 350
+  unit: F
 oven_fan: Off
-bake_time: 50 - 60 minutes
+oven_time: 50 - 60 minutes
 yields:
-  - loaves: 3
+  - amount: 3
+    unit: loaves
 ingredients:
-  - All Purpose Flour:
-      usda_num: 20581
-      amounts:
-        - amount: 3 1/2
-          unit: cups
-      substitutions:
-        - Oat Flour:
-          usda_num: '08122'
-          amounts:
-            - amount: '3 1/2'
-              unit: cups
-          notes:
-            - Make oat flour by processing instant oats in food processor.
-  - Baking Soda:
-      usda_num: 18372
-      amounts:
-        - amount: 2
-          unit: tsp
-  - Baking Powder:
-      usda_num: 18369
-      amounts:
-        - amount: 2
-          unit: tsp
-  - Salt:
-      usda_num: '02047'
-      amounts:
-        - amount: 1
-          unit: tsp
-  - Cinnamon, Ground:
-      usda_num: '02010'
-      amounts:
-        - amount: 2
-          unit: tsp
-  - Cloves, Ground:
-      usda_num: '02011'
-      amounts:
-        - amount: 1
-          unit: tsp
-  - Nutmeg, Ground:
-      usda_num: '02025'
-      amounts:
-        - amount: 1
-          unit: tsp
-  - Butter, Unsalted:
-      usda_num: '01145'
-      amounts:
-        - amount: 1
-          unit: cup
-      notes:
-        - Melted
-  - Granulated Sugar:
-      usda_num: 19335
-      amounts:
-        - amount: '1 1/2'
-          unit: cups
-  - Bananas:
-      usda_num: '09040'
-      amounts:
-        - amount: 6
-          unit: each
-  - Eggs, Large:
-      usda_num: '01123'
-      amounts:
-        - amount: 4
-          unit: cups
-  - Vanilla Extract:
-      usda_num: '02050'
-      amounts:
-        - amount: 2
-          unit: tsp
-  - Chocolate Chips, Bittersweet:
-      usda_num: 19080
-      amounts:
-        - amount: 2
-          unit: cups
-      notes:
-        - Optional
+  - ingredient: All Purpose Flour
+    usda_num: 20581
+    amounts:
+      - amount: 3 1/2
+        unit: cups
+    substitutions:
+      - ingredient: Oat Flour
+        usda_num: '08122'
+        amounts:
+          - amount: '3 1/2'
+            unit: cups
+        notes:
+          - Make oat flour by processing instant oats in food processor.
+  - ingredient: Baking Soda
+    usda_num: 18372
+    amounts:
+      - amount: 2
+        unit: tsp
+  - ingredient: Baking Powder
+    usda_num: 18369
+    amounts:
+      - amount: 2
+        unit: tsp
+  - ingredient: Salt
+    usda_num: '02047'
+    amounts:
+      - amount: 1
+        unit: tsp
+  - ingredient: Cinnamon, Ground
+    usda_num: '02010'
+    amounts:
+      - amount: 2
+        unit: tsp
+  - ingredient: Cloves, Ground
+    usda_num: '02011'
+    amounts:
+      - amount: 1
+        unit: tsp
+  - ingredient: Nutmeg, Ground
+    usda_num: '02025'
+    amounts:
+      - amount: 1
+        unit: tsp
+  - ingredient: Butter, Unsalted
+    usda_num: '01145'
+    amounts:
+      - amount: 1
+        unit: cup
+    notes:
+      - Melted
+  - ingredient: Granulated Sugar
+    usda_num: 19335
+    amounts:
+      - amount: '1 1/2'
+        unit: cups
+  - ingredient: Bananas
+    usda_num: '09040'
+    amounts:
+      - amount: 6
+        unit: each
+  - ingredient: Eggs, Large
+    usda_num: '01123'
+    amounts:
+      - amount: 4
+        unit: cups
+  - ingredient: Vanilla Extract
+    usda_num: '02050'
+    amounts:
+      - amount: 2
+        unit: tsp
+  - ingredient: Chocolate Chips, Bittersweet
+    usda_num: 19080
+    amounts:
+      - amount: 2
+        unit: cups
+    notes:
+      - Optional
 steps:
   - step:
       Preheat oven to 350F.

--- a/examples/orf-sample-1.yaml
+++ b/examples/orf-sample-1.yaml
@@ -1,58 +1,58 @@
 recipe_uuid: blah-001
 recipe_name: My Recipe
-author: Me
+source_authors: Me
 source_url: http://localhost/
-source_book: none
-oven_temp: none
-oven_fan: none
-bake_time: none
+source_book:
+oven_temp:
+oven_fan:
+oven_time:
 yields:
-  - servings:
-      4
-  - servings:
-      10
+  - amount: 4
+    unit: servings
+  - amount: 10
+    unit: servings
 ingredients:
-  - apple:
-      usda_num: 09003
-      amounts:
-        - amount: 4
-          unit: each
-        - amount: 10
-          unit: each
-      processing:
-        - whole
-        - raw
-      substitutions:
-        - pears:
-          usda_num: 09252
-          amounts:
-            - amount: 4
-              unit: each
-            - amount: 10
-              unit: each
-      notes:
-        - Use whole apples
-        - Pears may be substituted, but produce a different flavor and mouthfeel
-  - banana:
-      usda_num: 09040
-      amounts:
-        - amount: 4
-          unit: each
-        - amount: 10
-          unit: each
+  - ingredient: apple
+    usda_num: 09003
+    amounts:
+      - amount: 4
+        unit: each
+      - amount: 10
+        unit: each
+    processing:
+      - whole
+      - raw
+    substitutions:
+      - ingredient: pears
+        usda_num: 09252
+        amounts:
+          - amount: 4
+            unit: each
+          - amount: 10
+            unit: each
+    notes:
+      - Use whole apples
+      - Pears may be substituted, but produce a different flavor and mouthfeel
+  - ingredient: banana
+    usda_num: 09040
+    amounts:
+      - amount: 4
+        unit: each
+      - amount: 10
+        unit: each
 steps:
   - step:
       Hand out the apples
     haccp: The apples must be clean
     notes:
-    - Some people like green
-    - Some people like red
+      - Some people like green
+      - Some people like red
   - step:
       Hand out the bananas
     haccp: The bananas must be clean
     notes:
-    - Some people like green
-    - Most people don't like black 
+      - Some people like green
+      - Most people don't like black 
   - step:
       Enjoy
 notes:


### PR DESCRIPTION
Hello! I've been using openrecipeformat for a project I'm working on, and noticed some inconsistencies between the docs and the examples. This PR fixes some of those.

I also included changes to put the ingredient name as a field inside the ingredient dict. I found the current implementation harder to parse and validate, and I think this change makes it a bit easier to do.

Let me know if you have any feedback!