### PR TITLE
Improve table of contents structure for doc generation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,13 @@
-:orphan:
-
 .. _contents:
 
 Open Recipe Format
 ==================
+
+.. toctree::
+   :maxdepth: 2
+
+   topics/tutorials/*
+   topics/reference/*
 
 In the beginning, there was food. And then there were dishes. And somewhere down
 the line, people started writing down how to make the dishes. And most of them

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,13 +1,20 @@
+.. toctree::
+   :maxdepth: 4
+   :hidden:
+   :glob:
+
+   self
+   /topics/tutorials/walkthrough.rst
+   /topics/reference/orf.rst
+   /topics/reference/onf.rst
+   /topics/tutorials/using-alerts.rst
+   /topics/tutorials/git.rst
+   /topics/writing_recipes.rst
+
 .. _contents:
 
 Open Recipe Format
 ==================
-
-.. toctree::
-   :maxdepth: 2
-
-   topics/tutorials/*
-   topics/reference/*
 
 In the beginning, there was food. And then there were dishes. And somewhere down
 the line, people started writing down how to make the dishes. And most of them
@@ -55,7 +62,7 @@ start in their coding efforts.
 
 
 Getting Started
-===============
+---------------
 
 This walkthrough is made to help individuals get started quickly and gain a
 foundational knowledge of the Open Recipe Format:

--- a/doc/topics/tutorials/git.rst
+++ b/doc/topics/tutorials/git.rst
@@ -18,7 +18,7 @@ environments such as Gnome, KDE and Windows, is planned.
 
 
 Distributed Revision Control
-============================
+----------------------------
 Classical revision control systems used a centralized repository server, from
 which a user could check out files, modify them, and check them back in. Some
 older systems, such as CVS, would maintain version numbers of the repository
@@ -53,7 +53,7 @@ Confused yet? Don't worry, we'll take it step by step.
 
 
 Initializing a Repo
-===================
+-------------------
 This guide assumes the use of GitHub, a popular site which maintains Git
 repositories (known as "repos"), using both free and paid models. There are
 other stellar hosting options available, but by and large the usage will be the
@@ -79,7 +79,7 @@ TODO: Push the repository to origin
 
 
 Creating a Recipe
-=================
+-----------------
 We'll create a simple recipe, using your favorite text editor. This recipe will
 be saved as ~/git/myrecipes/apple.yaml:
 

--- a/doc/topics/tutorials/using-alerts.rst
+++ b/doc/topics/tutorials/using-alerts.rst
@@ -17,7 +17,7 @@ Please note that as with the `date` command, these abbreviations are case-
 sensitive; `M` refers to minutes, while `m` refers to months.
 
 Long-Term Durations
-===================
+-------------------
 The first question in many cooks' minds will be, why worry about anything longer
 than hours? Bear in mind that this format is intended to be usable in any
 situation where food is to be prepared. The following are all valid use cases:
@@ -28,7 +28,7 @@ situation where food is to be prepared. The following are all valid use cases:
 * Allowing whiskey to age in barrels for several years.
 
 Software-Based Alerts
-=====================
+---------------------
 With these considerations in mind, software can be written that helps the cook
 manage recipes, and alert the cook when an action needs to be taken.
 
@@ -42,6 +42,6 @@ at once, and allow the food producer to store their own internal storage
 information (bin codes, batch dates, etc) within the software.
 
 Examples
-========
+--------
 .. include:: <duck-prosciutto.yaml>
 


### PR DESCRIPTION
Looking at https://open-recipe-format.readthedocs.io/en/latest/, the generated docs does not give a full picture of the availability of documentation for the project, as the sidebar only ever lists the index page and its singular sub-heading. From there, there is a link to one other document, at which point you hit a bit of a dead-end with [A Basic Recipe](https://open-recipe-format.readthedocs.io/en/latest/topics/tutorials/walkthrough.html).

This is (based on my understanding of RTD and sphinx) due to a lack of `toctree`. In this PR, I have added the `toctree` directive to generate a nice sidebar that enables full navigation (minus the index.rst page) of all documentation. For the three pages, I have modified the second+ headers to be sub-headers so that they appear under that page on the sidebar, so that you would not see (for example), instead of the sidebar having the following:

* Introduction to Git
* Distributed Revision Control
* Initializing a Repo
* Creating a Recipe

It would be instead:

* Introduction to Git
    * Distributed Revision Control
    * Initializing a Repo
    * Creating a Recipe

which I believe is more the intention? I am happy to back this part of the PR out though and leave just the TOC if so desired.

An example of how this looks in practice is available at https://openrecipeformat.readthedocs.io/en/latest/