### PR TITLE
add basic python gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# python ignores
+__pycache__/
+*.py[cod]
+.python-version
+
+# sphinx build artifacts for RTD local testing
+doc/conf.py
+doc/_build
+
+# OS ignores
+.DS_Store


### PR DESCRIPTION
This adds a basic python gitignore file for the project which ignores all of the miscellaneous files that I generated while working on #21, and that probably other people would also not want to clutter up their git working directory.
