### PR TITLE
add .vscode to gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ doc/_build
 
 # OS ignores
 .DS_Store
+
+# IDE ignores
+.vscode/
+.idea/


### PR DESCRIPTION
Adds an ignore for vscode (and JetBrains) to avoid someone checking in those setting files for their editor.