### PR TITLE
add doc page to describe validating recipe

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,6 +7,7 @@
    /topics/tutorials/walkthrough.rst
    /topics/reference/orf.rst
    /topics/reference/onf.rst
+   /topics/tutorials/validating-recipe.rst
    /topics/tutorials/using-alerts.rst
    /topics/tutorials/git.rst
    /topics/writing_recipes.rst
@@ -21,7 +22,7 @@ the line, people started writing down how to make the dishes. And most of them
 weren't very good at it. And then they got computers, and they still weren't
 very good at it.
 
-The Open Recipe Format has been designed to solve some basic needs: accurate and 
+The Open Recipe Format has been designed to solve some basic needs: accurate and
 flexible storage of recipes. While there have been attempts in the past to
 create standardized computer recipe formats, they have so far met with failure.
 This stems from several problems, all of which stem from a lack of understanding
@@ -33,7 +34,7 @@ target home cooks. Commercial solutions exist, and address a host of new
 considerations that are not thought to relate to home cooks. The Open Recipe
 Format was initially created by a software engineer with a cooking degree and
 professional kitchen experience. Few, if any, other attempts at writing food
-software, much less standardized recipe data modeling, can make this claim. 
+software, much less standardized recipe data modeling, can make this claim.
 
 At the heart of the Open Recipe Format is an established file format called
 YAML. This format was chosen for a variety of reasons:
@@ -53,11 +54,11 @@ This repository is intended more for programmers than anyone else. As human-
 readable as the format is, it is likely to be confusing to many in its raw
 format. The job of the programmer is to use this spec in the development of
 their own software packages, websites, etc., and provide a friendly interface
-to the end-user. 
+to the end-user.
 
-Many of the files in this repository are intended to document the Open Recipe 
-Format. Others are examples, to help programmers understand how to best use the 
-format. And finally, sample source code is provided to give programmers a jump 
+Many of the files in this repository are intended to document the Open Recipe
+Format. Others are examples, to help programmers understand how to best use the
+format. And finally, sample source code is provided to give programmers a jump
 start in their coding efforts.
 
 

--- a/doc/topics/tutorials/validating-recipe.rst
+++ b/doc/topics/tutorials/validating-recipe.rst
@@ -4,9 +4,9 @@ Validating ORF Recipe
 The Open Recipe Format is, like other formats, a well-structured format that is
 capable of being parsed by machines. To help with ensuring that a recipe follows
 the :ref:`orf`, the project includes a JSON schema file. You can read more about
-what JSON Schema is `here <https://json-schema.org/>`_, but the gist of it is
-that gist of it is a highly structured file that can be used by tools to
-automatically validate your recipes.
+what JSON Schema is `here <https://json-schema.org/>`_, but the gist of it here
+is that it is a highly structured file that can be used by tools to automatically
+validate your recipes.
 
 The schema for ORF can be found within our GitHub repository in the
 `./schema.json <https://github.com/techhat/openrecipeformat/blob/master/schema.json>`_

--- a/doc/topics/tutorials/validating-recipe.rst
+++ b/doc/topics/tutorials/validating-recipe.rst
@@ -1,0 +1,33 @@
+Validating ORF Recipe
+=====================
+
+The Open Recipe Format is, like other formats, a well-structured format that is
+capable of being parsed by machines. To help with ensuring that a recipe follows
+the :ref:`orf`, the project includes a JSON schema file. You can read more about
+what JSON Schema is `here <https://json-schema.org/>`_, but the gist of it is
+that gist of it is a highly structured file that can be used by tools to
+automatically validate your recipes.
+
+The schema for ORF can be found within our GitHub repository in the
+`./schema.json <https://github.com/techhat/openrecipeformat/blob/master/schema.json>`_
+file. After you have downloaded that file to your machine, you may then use it
+to validate against your recipe using an external tool like
+`ajv <https://ajv.js.org/>`_ or a library like
+`python-jsonchema <https://python-jsonschema.readthedocs.io/en/stable/>`_. For
+example, to use ajv, after installing it via NPM, you could simply run:
+
+.. code-block:: bash
+
+    ajv validate -s /path/to/schema.json -d /path/to/recipe.yaml
+
+And it will then print out whether the YAML file follows the ORF reference, or
+if there are errors in it. The ORF project currently does not provide any
+explicit validation software, nor provides any recommendation beyond the ones
+above.
+
+Finally, this schema can then be hooked up to various IDEs and text editors
+to provide feeedback as you work. For example, if you use
+`VSCode <https://code.visualstudio.com/>`_, then you can use the
+`YAML <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml>`_
+extension, registering our schema manually with the service, and then get
+inline intellisense as you work.


### PR DESCRIPTION
Closes #17 in adding a doc page that describes how one could use the schema that was added in #24 to validate recipes on their machine. The choice of exact validator method is left to the reader, but a suggestion of ajv is given as it's relatively easy to get set-up on one's machine, and handles YAML documents out of the box transparently to the user.

A better option may be to find a similar tool like ajv that is a binary and installable via homebrew or apt-get, but I do not have any suggestions on what that might be.